### PR TITLE
close the open Menu when another Menu is triggered

### DIFF
--- a/lib/components/Menu.js
+++ b/lib/components/Menu.js
@@ -53,7 +53,7 @@ var Menu = module.exports = React.createClass({
   handleBlur: function(e) {
     // give next element a tick to take focus
     setTimeout(function() {
-      if (!document.activeElement.className.match(/Menu__/) && this.state.active){
+      if (!this.getDOMNode().contains(document.activeElement) && this.state.active){
         this.closeMenu();
       }
     }.bind(this), 1);

--- a/lib/components/MenuTrigger.js
+++ b/lib/components/MenuTrigger.js
@@ -19,13 +19,11 @@ var MenuTrigger = module.exports = React.createClass({
   handleKeyUp: function(e) {
     if (e.key === ' ')
       this.toggleActive();
-    return true;
   },
 
   handleKeyDown: function(e) {
     if (e.key === 'Enter')
       this.toggleActive();
-    return true;
   },
 
   handleClick: function() {

--- a/specs/Menu.spec.js
+++ b/specs/Menu.spec.js
@@ -1,65 +1,103 @@
 require('./helper');
 
-var menu;
-
 describe('Menu', function () {
-  beforeEach(function () {
-    menu = renderMenu();
+  describe('a single menu', function() {
+
+    var menu;
+
+    beforeEach(function () {
+      menu = renderMenu();
+    });
+
+    afterEach(function () {
+      unmountMenu();
+    });
+
+    it('should hide menu options by default', function () {
+      equal(menu.refs.options.getDOMNode().style.visibility, 'hidden');
+      equal(menu.refs.options.getDOMNode().getAttribute('aria-expanded'), 'false');
+      equal(menu.refs.options.getDOMNode().style.visibility, 'hidden');
+      ok(!menu.state.active);
+    });
+
+    it('should show menu options when trigger is clicked', function () {
+      TestUtils.Simulate.click(menu.refs.trigger.getDOMNode());
+      equal(menu.refs.options.getDOMNode().getAttribute('aria-expanded'), 'true');
+      equal(menu.refs.options.getDOMNode().style.visibility, 'visible');
+      ok(menu.state.active);
+    });
+
+    it('should toggle menu options trigger on enter key', function () {
+      TestUtils.Simulate.keyDown(menu.refs.trigger.getDOMNode(), {key: 'Enter'});
+      ok(menu.state.active);
+    });
+
+    it('should focus first option', function () {
+      TestUtils.Simulate.click(menu.refs.trigger.getDOMNode());
+      equal(menu.refs.options.getDOMNode().children[0], document.activeElement);
+    });
+
+    it('should have roles and aria attributes', function () {
+      var trigger = menu.refs.trigger.getDOMNode();
+      var options = menu.refs.options.getDOMNode();
+      equal(trigger.getAttribute('aria-owns'), options.getAttribute('id'));
+      equal(trigger.getAttribute('role'), 'button');
+      equal(trigger.getAttribute('aria-haspopup'), 'true');
+      equal(options.getAttribute('role'), 'menu');
+      equal(options.getAttribute('aria-expanded'), 'false');
+      equal(options.children[0].getAttribute('role'), 'menuitem');
+    });
+
+    // TODO: These tests aren't working for some reason
+    // it('should change selectedIndex on keydown', function () {
+    //   TestUtils.Simulate.click(menu.refs.trigger.getDOMNode());
+    //   TestUtils.Simulate.keyDown(menu.refs.options.getDOMNode(), {key: 'ArrowDown'});
+    //   equal(menu.state.selectedIndex, 1);
+    // });
+
+    // it('should select menu option on enter', function () {
+    //   TestUtils.Simulate.click(menu.refs.trigger.getDOMNode());
+    //   TestUtils.Simulate.keyDown(menu.refs.options.getDOMNode().children[1], {key: 'Enter'});
+    //   equal(menu.state.selectedIndex, 1);
+    // });
+
+    it('should make menu option disabled', function () {
+      equal(menu.refs.options.getDOMNode().children[3].getAttribute('aria-disabled'), 'true');
+    });
   });
 
-  afterEach(function () {
-    unmountMenu();
+  describe('multiple menus', function () {
+
+    var menuA, menuB, containerA, containerB;
+
+    beforeEach(function () {
+      containerA = document.createElement("div");
+      containerB = document.createElement("div");
+
+      document.body.appendChild(containerA);
+      document.body.appendChild(containerB);
+
+      menuA = renderMenu(containerA);
+      menuB = renderMenu(containerB);
+    });
+
+    afterEach(function () {
+      unmountMenu(containerA);
+      unmountMenu(containerB);
+    });
+
+    it('should close the active menu when clicking another menu', function (done) {
+      TestUtils.Simulate.click(menuA.refs.trigger.getDOMNode());
+      ok(menuA.state.active);
+
+      TestUtils.Simulate.click(menuB.refs.trigger.getDOMNode());
+      // Unfortunate implementation detail that `active` is not reset until the next execution cycle
+      setTimeout(function() {
+        ok(!menuA.state.active);
+        ok(menuB.state.active);
+        done();
+      }, 1);
+    });
   });
 
-  it('should hide menu options by default', function () {
-    equal(menu.refs.options.getDOMNode().style.visibility, 'hidden');
-    equal(menu.refs.options.getDOMNode().getAttribute('aria-expanded'), 'false');
-    equal(menu.refs.options.getDOMNode().style.visibility, 'hidden');
-    ok(!menu.state.active);
-  });
-
-  it('should show menu options when trigger is clicked', function () {
-    TestUtils.Simulate.click(menu.refs.trigger.getDOMNode());
-    equal(menu.refs.options.getDOMNode().getAttribute('aria-expanded'), 'true');
-    equal(menu.refs.options.getDOMNode().style.visibility, 'visible');
-    ok(menu.state.active);
-  });
-
-  it('should toggle menu options trigger on enter key', function () {
-    TestUtils.Simulate.keyDown(menu.refs.trigger.getDOMNode(), {key: 'Enter'});
-    ok(menu.state.active);
-  });
-
-  it('should focus first option', function () {
-    TestUtils.Simulate.click(menu.refs.trigger.getDOMNode());
-    equal(menu.refs.options.getDOMNode().children[0], document.activeElement);
-  });
-
-  it('should have roles and aria attributes', function () {
-    var trigger = menu.refs.trigger.getDOMNode();
-    var options = menu.refs.options.getDOMNode();
-    equal(trigger.getAttribute('aria-owns'), options.getAttribute('id'));
-    equal(trigger.getAttribute('role'), 'button');
-    equal(trigger.getAttribute('aria-haspopup'), 'true');
-    equal(options.getAttribute('role'), 'menu');
-    equal(options.getAttribute('aria-expanded'), 'false');
-    equal(options.children[0].getAttribute('role'), 'menuitem');
-  });
-
-  // TODO: These tests aren't working for some reason
-  // it('should change selectedIndex on keydown', function () {
-  //   TestUtils.Simulate.click(menu.refs.trigger.getDOMNode());
-  //   TestUtils.Simulate.keyDown(menu.refs.options.getDOMNode(), {key: 'ArrowDown'});
-  //   equal(menu.state.selectedIndex, 1);
-  // });
-
-  // it('should select menu option on enter', function () {
-  //   TestUtils.Simulate.click(menu.refs.trigger.getDOMNode());
-  //   TestUtils.Simulate.keyDown(menu.refs.options.getDOMNode().children[1], {key: 'Enter'});
-  //   equal(menu.state.selectedIndex, 1);
-  // });
-
-  it('should make menu option disabled', function () {
-    equal(menu.refs.options.getDOMNode().children[3].getAttribute('aria-disabled'), 'true');
-  });
 });

--- a/specs/helper.js
+++ b/specs/helper.js
@@ -13,7 +13,8 @@ strictEqual = assert.strictEqual;
 throws = assert.throws;
 
 var _menuNode;
-renderMenu = function() {
+renderMenu = function(container) {
+  container = container || document.body;
   return React.renderComponent((
     <Menu>
       <MenuTrigger>I am the trigger, goo goo goo joob</MenuTrigger>
@@ -24,9 +25,11 @@ renderMenu = function() {
         <MenuOption disabled={true}>Disabled</MenuOption>
       </MenuOptions>
     </Menu>
-  ), document.body);
+  ), container);
 };
 
-unmountMenu = function() {
-  React.unmountComponentAtNode(document.body);
+unmountMenu = function(container) {
+  container = container || document.body;
+  React.unmountComponentAtNode(container);
 };
+


### PR DESCRIPTION
refs #6 

Also removes the `return true;` calls in MenuTrigger because they have no effect (I'm pretty sure), and they cause warnings with React 0.12.2