### PR TITLE
[fixed] Use Reactify transform when building

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,11 @@
   "browserify-shim": {
     "react": "global:React"
   },
+  "browserify": {
+    "transform": [
+      "reactify"
+    ]
+  },
   "dependencies": {
     "js-stylesheet": "0.0.1"
   }


### PR DESCRIPTION
Hey, thanks for this useful component!

I ran into a snag building an app with Browserify that uses this. The Reactify transform is, by default, not applied to your app's dependencies, so the JSX in react-menu wasn't getting processed. (See andreypopp/reactify#20.) This patch fixes it for me, and according to Andrey, is the correct way to go about this.