### PR TITLE
Add keepOpenOnSelect boolean option to Menu

### DIFF
--- a/lib/components/Menu.js
+++ b/lib/components/Menu.js
@@ -20,6 +20,10 @@ var Menu = module.exports = React.createClass({
 
   mixins: [buildClassName],
 
+  propTypes: {
+    keepOpenOnSelect: React.PropTypes.bool
+  },
+
   childContextTypes: {
     id: React.PropTypes.string,
     active: React.PropTypes.bool
@@ -40,6 +44,12 @@ var Menu = module.exports = React.createClass({
       horizontalPlacement: 'right', // only 'right' || 'left'
       verticalPlacement: 'bottom' // only 'top' || 'bottom'
     };
+  },
+
+  onSelectionMade: function() {
+    if (!this.props.keepOpenOnSelect) {
+      this.closeMenu()
+    }
   },
 
   closeMenu: function() {
@@ -125,7 +135,7 @@ var Menu = module.exports = React.createClass({
             ref: 'options',
             horizontalPlacement: this.state.horizontalPlacement,
             verticalPlacement: this.state.verticalPlacement,
-            onSelectionMade: this.closeMenu
+            onSelectionMade: this.onSelectionMade
           });
         }
       }.bind(this));


### PR DESCRIPTION
This is useful for menus that have checkbox-like options that toggle between states and the user needs to see the state transition.