### PR TITLE
Update to React 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "karma-firefox-launcher": "0.1.3",
     "karma-mocha": "0.1.3",
     "mocha": "1.20.1",
-    "react": "^0.12.0",
+    "react": "^0.13.0",
     "reactify": "^0.14.0",
     "rf-release": "0.3.1",
     "uglify-js": "2.4.15",
     "webpack-dev-server": "1.6.5"
   },
   "peerDependencies": {
-    "react": "^0.12.0"
+    "react": "^0.13.0"
   },
   "tags": [
     "react",


### PR DESCRIPTION
React is already at `version 0.13.3`, and because the peer dependency was set to `0.12.0` npm errors, because `The package react does not satisfy its siblings' peerDependencies requirements!`.

With this PR the React version is upped to `0.13.0`.