### PR TITLE
Fixing 'Warning: module.exports.type is deprecated.  Please use modul…

### DIFF
--- a/dist/react-menu.js
+++ b/dist/react-menu.js
@@ -106,7 +106,7 @@ var Menu = module.exports = React.createClass({
     var trigger;
     if(this.verifyTwoChildren()) {
       React.Children.forEach(this.props.children, function(child){
-        if (child.type === MenuTrigger.type) {
+        if (child === MenuTrigger) {
           trigger = cloneWithProps(child, {
             ref: 'trigger',
             onToggleActive: this.handleTriggerToggle
@@ -121,7 +121,7 @@ var Menu = module.exports = React.createClass({
     var options;
     if(this.verifyTwoChildren()) {
       React.Children.forEach(this.props.children, function(child){
-        if (child.type === MenuOptions.type) {
+        if (child === MenuOptions) {
           options = cloneWithProps(child, {
             ref: 'options',
             horizontalPlacement: this.state.horizontalPlacement,

--- a/lib/components/Menu.js
+++ b/lib/components/Menu.js
@@ -105,7 +105,7 @@ var Menu = module.exports = React.createClass({
     var trigger;
     if(this.verifyTwoChildren()) {
       React.Children.forEach(this.props.children, function(child){
-        if (child.type === MenuTrigger.type) {
+        if (child === MenuTrigger) {
           trigger = cloneWithProps(child, {
             ref: 'trigger',
             onToggleActive: this.handleTriggerToggle
@@ -120,7 +120,7 @@ var Menu = module.exports = React.createClass({
     var options;
     if(this.verifyTwoChildren()) {
       React.Children.forEach(this.props.children, function(child){
-        if (child.type === MenuOptions.type) {
+        if (child === MenuOptions) {
           options = cloneWithProps(child, {
             ref: 'options',
             horizontalPlacement: this.state.horizontalPlacement,


### PR DESCRIPTION
…e.exports instead' by making react component comparisons directly.

https://github.com/facebook/react/pull/4009 shows that the .type method has been deprecated in 0.13 and will be removed completely in 0.14.  