### PR TITLE
Prevent window from scrolling when navigating menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ See example at [http://instructure-react.github.io/react-menu/](http://instructu
 ```html
 /** @jsx React.DOM */
 
-var react = require('react');
+var React = require('react');
+var ReactDOM = require('react-dom');
 
 var Menu = require('react-menu');
 var MenuTrigger = Menu.MenuTrigger;
@@ -39,7 +40,7 @@ var App = React.createClass({
           </div>
 
           <MenuOption disabled={true} onDisabledSelect={this.otherHanlder}>
-            diabled option
+            disabled option
           </MenuOption>
 
         </MenuOptions>
@@ -48,7 +49,7 @@ var App = React.createClass({
   }
 });
 
-React.renderComponent(<App />, document.body);
+ReactDOM.render(<App />, document.body);
 
 ```
 

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -1,6 +1,7 @@
 /** @jsx React.DOM */
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var Menu = require('../../lib/index');
 var MenuTrigger = require('../../lib/components/MenuTrigger');
 var MenuOptions = require('../../lib/components/MenuOptions');
@@ -65,4 +66,4 @@ var App = React.createClass({
 });
 
 
-React.renderComponent(<App/>, document.getElementById('example'));
+ReactDOM.render(<App/>, document.getElementById('example'));

--- a/lib/components/MenuOption.js
+++ b/lib/components/MenuOption.js
@@ -37,6 +37,7 @@ var MenuOption = module.exports = React.createClass({
   },
 
   handleKeyDown: function(e) {
+    e.preventDefault();
     if (e.key === 'Enter') {
       this.onSelect();
     }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "reactify": "^1.1.1",
     "rf-release": "0.4.0",
     "uglify-js": "2.6.1",
-    "webpack-dev-server": "1.14.1"
+    "webpack-dev-server": "1.14.1",
+    "webpack": "1.13.1"
   },
   "peerDependencies": {
     "react": "^0.14.7"


### PR DESCRIPTION
refs https://github.com/instructure-react/react-menu/issues/32

This stops the entire page from moving when the user is just trying
to navigate the menu options using arrow keys.

Also updates the included basic example for react-menu.